### PR TITLE
Building to 'dist' and running next from there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .next
 node_modules
-./pages
-./components
+dist

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "scripts": {
     "prebuild": "tsc",
-    "build": "next build",
+    "build": "next build ./dist",
     "predev": "tsc",
-    "dev": "concurrently \"npm run watch:tsc\" \"next\"",
-    "start": "next start",
+    "dev": "concurrently \"npm run watch:tsc\" \"next ./dist\"",
+    "start": "next start ./dist",
     "tsc": "tsc",
     "watch:tsc": "tsc --watch"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
         "module": "es6",        
         "noImplicitAny": false,
         "sourceMap": true,
-        "outDir": "./"
+        "outDir": "./dist"
     },
     "exclude": [
 		"node_modules"


### PR DESCRIPTION
Sorry about the patch bombing but it turned out that you could already run `next` from wherever you want (it was documented in the source code). So now the source is in `src` and the built stuff (both `tsc` and `next`) is in `dist`, which is ignored by git. Unfortunately `tscomp` must have an `index.ts` as a starting point, which `next` dosen't really have (right?). But I guess `gulp` could be setup for just moving the static content to `dist`.